### PR TITLE
ADD: Remove overflows for blockquotes and <code>

### DIFF
--- a/themes/default/style.css.in
+++ b/themes/default/style.css.in
@@ -75,6 +75,7 @@ blockquote {
 	border-left:solid 4px BQ_BORDER_COLOR;
 	margin-left:12px;
 	padding:12px 12px 12px 24px;
+	word-break: break-word;
 }
 blockquote img { 
 	margin:12px 0px;
@@ -84,4 +85,7 @@ blockquote iframe {
 }
 img {
 	max-width:100%;
+}
+pre {
+	overflow-x: scroll;
 }


### PR DESCRIPTION
I added wrapping to `blockquotes` and `code` elements for better readability. 

See below for an example.

![random](https://user-images.githubusercontent.com/52892257/85954361-2dde1f80-b977-11ea-942e-e8c49c01b3d3.gif)
