### PR TITLE
Prevent `read` from trimming whitespace, resulting in broken indentation

### DIFF
--- a/internal/globals.sh
+++ b/internal/globals.sh
@@ -503,7 +503,7 @@ function post_markdown {
 		cat "${TMP2}" > "${TMP1}"
 	else
 		HEADINGS=( )
-		while read LINE
+		while IFS= read -r LINE
 		do
 			if [[ "$(echo "${LINE}" | grep "^<h[[:digit:]]>.*</h[[:digit:]]>" )" == "" ]]
 			then


### PR DESCRIPTION
https://mywiki.wooledge.org/IFS

upstreaming of https://github.com/aadibajpai/blog/pull/4/

as seen on https://aadibajpai.com/blog/